### PR TITLE
After killing process, set `jazzradio--process` to nil

### DIFF
--- a/jazzradio.el
+++ b/jazzradio.el
@@ -167,6 +167,7 @@
         (message "%s is not playing now" name)
       (when (y-or-n-p (format "Stop '%s' ?" name))
         (kill-process jazzradio--process)
+        (setq jazzradio--process nil)
         (jazzradio--update-status channel nil)
         (tabulated-list-print t)))))
 


### PR DESCRIPTION
After stopped playing channel, we can't play channel again.
This pull request fixes this.
